### PR TITLE
support "min-width: 0" expression on mobile-first sort

### DIFF
--- a/lib/create-sort.js
+++ b/lib/create-sort.js
@@ -31,8 +31,16 @@ const maxValue = Number.MAX_VALUE;
  * @param {string} length
  * @return {number}
  */
-function _getQueryLength(length) {
-	length = /(-?\d*\.?\d+)(ch|em|ex|px|rem)/.exec(length);
+function _getQueryLength(query) {
+	let length = /(-?\d*\.?\d+)(ch|em|ex|px|rem)/.exec(query);
+
+	if (length === null && (isMinWidth(query) || isMinHeight(query))) {
+		length = /(\d)/.exec(query);
+	}
+
+	if (length === '0') {
+		return 0;
+	}
 
 	if (length === null) {
 		return maxValue;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -100,6 +100,17 @@ test(`simple #2. desktop-first`, () => {
 	expect(received).toBe(expected);
 });
 
+test(`simple #3. mobile-first`, () => {
+	const receivedOrder = ['screen and (min-width: 640px)', 'screen and (min-width: 0)'];
+
+	const expectedOrder = ['screen and (min-width: 0)', 'screen and (min-width: 640px)'];
+
+	const expected = expectedOrder.join('\n');
+	const received = receivedOrder.sort(sortCSSmq).join('\n');
+
+	expect(received).toBe(expected);
+});
+
 test(`without dimension #1. mobile-first`, () => {
 	const receivedOrder = [
 		'tv',


### PR DESCRIPTION
Our web-app uses vuetify. Vuetify uses "min-width: 0" expression within media queries. This PR fixes the mobile-first sort to support that. Would you consider to merge this PR.