### PR TITLE
Media Queries Level 4 "range" support

### DIFF
--- a/lib/create-sort.js
+++ b/lib/create-sort.js
@@ -3,9 +3,9 @@
 // ----------------------------------------
 
 const minMaxWidth = /(!?\(\s*min(-device-)?-width)(.|\n)+\(\s*max(-device)?-width/i;
-const minWidth = /\(\s*min(-device)?-width/i;
+const minWidth = /\(\s*min(-device)?-width|\(\s*width\s*>(=)?/i;
 const maxMinWidth = /(!?\(\s*max(-device)?-width)(.|\n)+\(\s*min(-device)?-width/i;
-const maxWidth = /\(\s*max(-device)?-width/i;
+const maxWidth = /\(\s*max(-device)?-width|\(\s*width\s*<(=)?/i;
 
 const isMinWidth = _testQuery(minMaxWidth, maxMinWidth, minWidth);
 const isMaxWidth = _testQuery(maxMinWidth, minMaxWidth, maxWidth);

--- a/lib/create-sort.js
+++ b/lib/create-sort.js
@@ -3,19 +3,21 @@
 // ----------------------------------------
 
 const minMaxWidth =
-	/(!?\(\s*min(-device)?-width)(.|\n)+\(\s*max(-device)?-width|\(\s*width\s*>(=)?(.|\n)+\(\s*width\s*<(=)?/i;
+	/(!?\(\s*min(-device)?-width)(.|\n)+\(\s*max(-device)?-width|\(\s*width\s*>(=)?(.|\n)+\(\s*width\s*<(=)?|(!?\(.*<(=)?\s*width\s*<(=)?)/i;
 const minWidth = /\(\s*min(-device)?-width|\(\s*width\s*>(=)?/i;
 const maxMinWidth =
-	/(!?\(\s*max(-device)?-width)(.|\n)+\(\s*min(-device)?-width|\(\s*width\s*<(=)?(.|\n)+\(\s*width\s*>(=)?/i;
+	/(!?\(\s*max(-device)?-width)(.|\n)+\(\s*min(-device)?-width|\(\s*width\s*<(=)?(.|\n)+\(\s*width\s*>(=)?|(!?\(.*>(=)?\s*width\s*>(=)?)/i;
 const maxWidth = /\(\s*max(-device)?-width|\(\s*width\s*<(=)?/i;
 
 const isMinWidth = _testQuery(minMaxWidth, maxMinWidth, minWidth);
 const isMaxWidth = _testQuery(maxMinWidth, minMaxWidth, maxWidth);
 
-const minMaxHeight = /(!?\(\s*min(-device)?-height)(.|\n)+\(\s*max(-device)?-height/i;
-const minHeight = /\(\s*min(-device)?-height/i;
-const maxMinHeight = /(!?\(\s*max(-device)?-height)(.|\n)+\(\s*min(-device)?-height/i;
-const maxHeight = /\(\s*max(-device)?-height/i;
+const minMaxHeight =
+	/(!?\(\s*min(-device)?-height)(.|\n)+\(\s*max(-device)?-height|\(\s*height\s*>(=)?(.|\n)+\(\s*height\s*<(=)?|(!?\(.*<(=)?\s*height\s*<(=)?)/i;
+const minHeight = /\(\s*min(-device)?-height|\(\s*height\s*>(=)?/i;
+const maxMinHeight =
+	/(!?\(\s*max(-device)?-height)(.|\n)+\(\s*min(-device)?-height|\(\s*height\s*<(=)?(.|\n)+\(\s*height\s*>(=)?|(!?\(.*>(=)?\s*height\s*>(=)?)/i;
+const maxHeight = /\(\s*max(-device)?-height|\(\s*height\s*<(=)?/i;
 
 const isMinHeight = _testQuery(minMaxHeight, maxMinHeight, minHeight);
 const isMaxHeight = _testQuery(maxMinHeight, minMaxHeight, maxHeight);

--- a/lib/create-sort.js
+++ b/lib/create-sort.js
@@ -2,9 +2,11 @@
 // Private
 // ----------------------------------------
 
-const minMaxWidth = /(!?\(\s*min(-device-)?-width)(.|\n)+\(\s*max(-device)?-width/i;
+const minMaxWidth =
+	/(!?\(\s*min(-device)?-width)(.|\n)+\(\s*max(-device)?-width|\(\s*width\s*>(=)?(.|\n)+\(\s*width\s*<(=)?/i;
 const minWidth = /\(\s*min(-device)?-width|\(\s*width\s*>(=)?/i;
-const maxMinWidth = /(!?\(\s*max(-device)?-width)(.|\n)+\(\s*min(-device)?-width/i;
+const maxMinWidth =
+	/(!?\(\s*max(-device)?-width)(.|\n)+\(\s*min(-device)?-width|\(\s*width\s*<(=)?(.|\n)+\(\s*width\s*>(=)?/i;
 const maxWidth = /\(\s*max(-device)?-width|\(\s*width\s*<(=)?/i;
 
 const isMinWidth = _testQuery(minMaxWidth, maxMinWidth, minWidth);

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -9,18 +9,34 @@ test(`simple #1. mobile-first`, () => {
 		'screen and (min-width: 640px)',
 		'screen and (min-width: 1280px)',
 		'screen and (min-width: 768px)',
-		'screen and (max-width: 1280px)'
+		'screen and (max-width: 1280px)',
+		'screen and (width < 640px)',
+		'screen and (width >= 980px)',
+		'screen and (width <= 980px)',
+		'screen and (width <= 768px)',
+		'screen and (width > 640px)',
+		'screen and (width >= 1280px)',
+		'screen and (width > 768px)',
+		'screen and (width < 1280px)',
 	];
 
 	const expectedOrder = [
 		'screen and (min-width: 640px)',
+		'screen and (width > 640px)',
 		'screen and (min-width: 768px)',
+		'screen and (width > 768px)',
 		'screen and (min-width: 980px)',
+		'screen and (width >= 980px)',
 		'screen and (min-width: 1280px)',
+		'screen and (width >= 1280px)',
 		'screen and (max-width: 1280px)',
+		'screen and (width < 1280px)',
 		'screen and (max-width: 980px)',
+		'screen and (width <= 980px)',
 		'screen and (max-width: 768px)',
-		'screen and (max-width: 640px)'
+		'screen and (width <= 768px)',
+		'screen and (max-width: 640px)',
+		'screen and (width < 640px)',
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -38,18 +54,34 @@ test(`simple #1. desktop-first`, () => {
 		'screen and (min-width: 640px)',
 		'screen and (min-width: 1280px)',
 		'screen and (min-width: 768px)',
-		'screen and (max-width: 1280px)'
+		'screen and (max-width: 1280px)',
+		'screen and (width < 640px)',
+		'screen and (width > 980px)',
+		'screen and (width <= 980px)',
+		'screen and (width < 768px)',
+		'screen and (width > 640px)',
+		'screen and (width >= 1280px)',
+		'screen and (width >= 768px)',
+		'screen and (width <= 1280px)',
 	];
 
 	const expectedOrder = [
+		'screen and (width <= 1280px)',
 		'screen and (max-width: 1280px)',
+		'screen and (width <= 980px)',
 		'screen and (max-width: 980px)',
+		'screen and (width < 768px)',
 		'screen and (max-width: 768px)',
+		'screen and (width < 640px)',
 		'screen and (max-width: 640px)',
+		'screen and (width > 640px)',
 		'screen and (min-width: 640px)',
+		'screen and (width >= 768px)',
 		'screen and (min-width: 768px)',
+		'screen and (width > 980px)',
 		'screen and (min-width: 980px)',
-		'screen and (min-width: 1280px)'
+		'screen and (width >= 1280px)',
+		'screen and (min-width: 1280px)',
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -63,14 +95,22 @@ test(`simple #2. mobile-first`, () => {
 		'screen and (max-width: 640px)',
 		'screen and (max-width: 640px)',
 		'screen and (min-width: 1280px)',
-		'screen and (max-width: 640px)'
+		'screen and (max-width: 640px)',
+		'screen and (width < 640px)',
+		'screen and (width < 640px)',
+		'screen and (width > 1280px)',
+		'screen and (width < 640px)',
 	];
 
 	const expectedOrder = [
 		'screen and (min-width: 1280px)',
+		'screen and (width > 1280px)',
 		'screen and (max-width: 640px)',
 		'screen and (max-width: 640px)',
-		'screen and (max-width: 640px)'
+		'screen and (max-width: 640px)',
+		'screen and (width < 640px)',
+		'screen and (width < 640px)',
+		'screen and (width < 640px)',
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -84,14 +124,22 @@ test(`simple #2. desktop-first`, () => {
 		'screen and (max-width: 640px)',
 		'screen and (max-width: 640px)',
 		'screen and (min-width: 1280px)',
-		'screen and (max-width: 640px)'
+		'screen and (max-width: 640px)',
+		'screen and (width < 640px)',
+		'screen and (width < 640px)',
+		'screen and (width > 1280px)',
+		'screen and (width < 640px)',
 	];
 
 	const expectedOrder = [
+		'screen and (width < 640px)',
+		'screen and (width < 640px)',
+		'screen and (width < 640px)',
 		'screen and (max-width: 640px)',
 		'screen and (max-width: 640px)',
 		'screen and (max-width: 640px)',
-		'screen and (min-width: 1280px)'
+		'screen and (width > 1280px)',
+		'screen and (min-width: 1280px)',
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -101,9 +149,19 @@ test(`simple #2. desktop-first`, () => {
 });
 
 test(`simple #3. mobile-first`, () => {
-	const receivedOrder = ['screen and (min-width: 640px)', 'screen and (min-width: 0)'];
+	const receivedOrder = [
+		'screen and (min-width: 640px)',
+		'screen and (min-width: 0)',
+		'screen and (width > 640px)',
+		'screen and (width > 0)',
+	];
 
-	const expectedOrder = ['screen and (min-width: 0)', 'screen and (min-width: 640px)'];
+	const expectedOrder = [
+		'screen and (min-width: 0)',
+		'screen and (width > 0)',
+		'screen and (min-width: 640px)',
+		'screen and (width > 640px)',
+	];
 
 	const expected = expectedOrder.join('\n');
 	const received = receivedOrder.sort(sortCSSmq).join('\n');
@@ -178,20 +236,28 @@ test(`mixed #1. mobile-first`, () => {
 		'tv',
 		'print and (orientation: landscape)',
 		'screen and (min-width: 1280px)',
+		'screen and (width > 1280px)',
 		'screen and (max-width: 640px)',
+		'screen and (width < 640px)',
 		'screen and (orientation: landscape)',
 		'print',
 		'screen and (orientation: portrait)',
 		'screen and (min-width: 768px)',
+		'screen and (width > 768px)',
 		'screen and (max-width: 1280px)',
+		'screen and (width < 1280px)',
 		'print and (orientation: portrait)'
 	];
 
 	const expectedOrder = [
 		'screen and (min-width: 768px)',
+		'screen and (width > 768px)',
 		'screen and (min-width: 1280px)',
+		'screen and (width > 1280px)',
 		'screen and (max-width: 1280px)',
+		'screen and (width < 1280px)',
 		'screen and (max-width: 640px)',
+		'screen and (width < 640px)',
 		'screen and (orientation: landscape)',
 		'screen and (orientation: portrait)',
 		'tv',
@@ -211,19 +277,27 @@ test(`mixed #1. desktop-first`, () => {
 		'tv',
 		'print and (orientation: landscape)',
 		'screen and (min-width: 1280px)',
+		'screen and (width > 1280px)',
 		'screen and (max-width: 640px)',
+		'screen and (width < 640px)',
 		'screen and (orientation: landscape)',
 		'print',
 		'screen and (orientation: portrait)',
 		'screen and (min-width: 768px)',
+		'screen and (width > 768px)',
 		'screen and (max-width: 1280px)',
+		'screen and (width < 1280px)',
 		'print and (orientation: portrait)'
 	];
 
 	const expectedOrder = [
+		'screen and (width < 1280px)',
 		'screen and (max-width: 1280px)',
+		'screen and (width < 640px)',
 		'screen and (max-width: 640px)',
+		'screen and (width > 768px)',
 		'screen and (min-width: 768px)',
+		'screen and (width > 1280px)',
 		'screen and (min-width: 1280px)',
 		'screen and (orientation: landscape)',
 		'screen and (orientation: portrait)',
@@ -284,67 +358,67 @@ test(`multiline #2. mobile-first`, () => {
 	// Edge cases
 	const receivedOrder = [
 		`
-    
+
     @media (min-width: 48em)
-    
-    
+
+
        and (max-width: 59.999em)
-       
+
        `,
 		`
-    
-    
+
+
               @media (min-width: 40em)
-              
+
        and (max-width: 47.999em)
-       
-       
+
+
        `,
 		`
-    
-    
-    
+
+
+
     @media (min-width: 15em)
-    
-          
-    
+
+
+
        and (max-width: 47.999em)
-       
-       
-       
+
+
+
        `
 	];
 
 	const expectedOrder = [
 		`
-    
-    
-    
+
+
+
     @media (min-width: 15em)
-    
-          
-    
+
+
+
        and (max-width: 47.999em)
-       
-       
-       
+
+
+
        `,
 		`
-    
-    
+
+
               @media (min-width: 40em)
-              
+
        and (max-width: 47.999em)
-       
-       
+
+
        `,
 		`
-    
+
     @media (min-width: 48em)
-    
-    
+
+
        and (max-width: 59.999em)
-       
+
        `
 	];
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -17,7 +17,7 @@ test(`simple #1. mobile-first`, () => {
 		'screen and (width > 640px)',
 		'screen and (width >= 1280px)',
 		'screen and (width > 768px)',
-		'screen and (width < 1280px)',
+		'screen and (width < 1280px)'
 	];
 
 	const expectedOrder = [
@@ -36,7 +36,7 @@ test(`simple #1. mobile-first`, () => {
 		'screen and (max-width: 768px)',
 		'screen and (width <= 768px)',
 		'screen and (max-width: 640px)',
-		'screen and (width < 640px)',
+		'screen and (width < 640px)'
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -62,7 +62,7 @@ test(`simple #1. desktop-first`, () => {
 		'screen and (width > 640px)',
 		'screen and (width >= 1280px)',
 		'screen and (width >= 768px)',
-		'screen and (width <= 1280px)',
+		'screen and (width <= 1280px)'
 	];
 
 	const expectedOrder = [
@@ -81,7 +81,7 @@ test(`simple #1. desktop-first`, () => {
 		'screen and (width > 980px)',
 		'screen and (min-width: 980px)',
 		'screen and (width >= 1280px)',
-		'screen and (min-width: 1280px)',
+		'screen and (min-width: 1280px)'
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -99,7 +99,7 @@ test(`simple #2. mobile-first`, () => {
 		'screen and (width < 640px)',
 		'screen and (width < 640px)',
 		'screen and (width > 1280px)',
-		'screen and (width < 640px)',
+		'screen and (width < 640px)'
 	];
 
 	const expectedOrder = [
@@ -110,7 +110,7 @@ test(`simple #2. mobile-first`, () => {
 		'screen and (max-width: 640px)',
 		'screen and (width < 640px)',
 		'screen and (width < 640px)',
-		'screen and (width < 640px)',
+		'screen and (width < 640px)'
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -128,7 +128,7 @@ test(`simple #2. desktop-first`, () => {
 		'screen and (width < 640px)',
 		'screen and (width < 640px)',
 		'screen and (width > 1280px)',
-		'screen and (width < 640px)',
+		'screen and (width < 640px)'
 	];
 
 	const expectedOrder = [
@@ -139,7 +139,7 @@ test(`simple #2. desktop-first`, () => {
 		'screen and (max-width: 640px)',
 		'screen and (max-width: 640px)',
 		'screen and (width > 1280px)',
-		'screen and (min-width: 1280px)',
+		'screen and (min-width: 1280px)'
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -153,14 +153,14 @@ test(`simple #3. mobile-first`, () => {
 		'screen and (min-width: 640px)',
 		'screen and (min-width: 0)',
 		'screen and (width > 640px)',
-		'screen and (width > 0)',
+		'screen and (width > 0)'
 	];
 
 	const expectedOrder = [
 		'screen and (min-width: 0)',
 		'screen and (width > 0)',
 		'screen and (min-width: 640px)',
-		'screen and (width > 640px)',
+		'screen and (width > 640px)'
 	];
 
 	const expected = expectedOrder.join('\n');

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -328,24 +328,52 @@ test(`multiline #1. mobile-first`, () => {
 		`@media (min-width: 3em)
        and (max-width: 48.999em)`,
 		`@media (min-width: 31em)
-       and (max-width: 48.999em)`
+       and (max-width: 48.999em)`,
+		`@media (width > 48em)
+       and (width < 59.999em)`,
+		`@media (width > 40em)
+       and (width < 47.999em)`,
+		`@media (width > 15em)
+       and (width < 47.999em)`,
+		`@media (width > 2em)
+       and (width < 47.999em)`,
+		`@media (width > 20em)
+       and (width < 47.999em)`,
+		`@media (width > 3em)
+       and (width < 48.999em)`,
+		`@media (width > 31em)
+       and (width < 48.999em)`
 	];
 
 	const expectedOrder = [
 		`@media (min-width: 2em)
        and (max-width: 47.999em)`,
+		`@media (width > 2em)
+       and (width < 47.999em)`,
 		`@media (min-width: 3em)
        and (max-width: 48.999em)`,
+		`@media (width > 3em)
+       and (width < 48.999em)`,
 		`@media (min-width: 15em)
        and (max-width: 47.999em)`,
+		`@media (width > 15em)
+       and (width < 47.999em)`,
 		`@media (min-width: 20em)
        and (max-width: 47.999em)`,
+		`@media (width > 20em)
+       and (width < 47.999em)`,
 		`@media (min-width: 31em)
        and (max-width: 48.999em)`,
+		`@media (width > 31em)
+       and (width < 48.999em)`,
 		`@media (min-width: 40em)
        and (max-width: 47.999em)`,
+		`@media (width > 40em)
+       and (width < 47.999em)`,
 		`@media (min-width: 48em)
-       and (max-width: 59.999em)`
+       and (max-width: 59.999em)`,
+		`@media (width > 48em)
+       and (width < 59.999em)`
 	];
 
 	const expected = expectedOrder.join('\n');
@@ -386,6 +414,36 @@ test(`multiline #2. mobile-first`, () => {
 
 
 
+       `,
+		`
+
+    @media (width > 48em)
+
+
+       and (width < 59.999em)
+
+       `,
+		`
+
+
+              @media (width > 40em)
+
+       and (width < 47.999em)
+
+
+       `,
+		`
+
+
+
+    @media (width > 15em)
+
+
+
+       and (width < 47.999em)
+
+
+
        `
 	];
 
@@ -406,9 +464,31 @@ test(`multiline #2. mobile-first`, () => {
 		`
 
 
+
+    @media (width > 15em)
+
+
+
+       and (width < 47.999em)
+
+
+
+       `,
+		`
+
+
               @media (min-width: 40em)
 
        and (max-width: 47.999em)
+
+
+       `,
+		`
+
+
+              @media (width > 40em)
+
+       and (width < 47.999em)
 
 
        `,
@@ -418,6 +498,14 @@ test(`multiline #2. mobile-first`, () => {
 
 
        and (max-width: 59.999em)
+
+       `,
+		`
+
+    @media (width > 48em)
+
+
+       and (width < 59.999em)
 
        `
 	];

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -321,6 +321,7 @@ test(`multiline #1. mobile-first`, () => {
        and (max-width: 47.999em)`,
 		`@media (min-width: 15em)
        and (max-width: 47.999em)`,
+		`@media (0 < width < 20px)`,
 		`@media (min-width: 2em)
        and (max-width: 47.999em)`,
 		`@media (min-width: 20em)
@@ -342,10 +343,12 @@ test(`multiline #1. mobile-first`, () => {
 		`@media (width > 3em)
        and (width < 48.999em)`,
 		`@media (width > 31em)
-       and (width < 48.999em)`
+       and (width < 48.999em)`,
+		`@media (31em < width < 48.999em )`
 	];
 
 	const expectedOrder = [
+		`@media (0 < width < 20px)`,
 		`@media (min-width: 2em)
        and (max-width: 47.999em)`,
 		`@media (width > 2em)
@@ -362,6 +365,7 @@ test(`multiline #1. mobile-first`, () => {
        and (max-width: 47.999em)`,
 		`@media (width > 20em)
        and (width < 47.999em)`,
+		`@media (31em < width < 48.999em )`,
 		`@media (min-width: 31em)
        and (max-width: 48.999em)`,
 		`@media (width > 31em)


### PR DESCRIPTION
This PR added support for [Media Queries Level 4](https://www.w3.org/TR/mediaqueries-4/)/["range"](https://www.w3.org/TR/mediaqueries-4/#mq-ranges) type feature

Accodrig to issue https://github.com/yunusga/postcss-sort-media-queries/issues/45