### PR TITLE
fix(es6): Ensure relative imports have file extensions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,3 @@
-import createSort from './create-sort';
-import loadConfig from './load-config';
+import createSort from './create-sort.js';
+import loadConfig from './load-config.js';
 export default createSort(loadConfig());


### PR DESCRIPTION
Hello!

I'm trying to make my renovate PR work with the newly released 3.0.0 version, but I can't run my webpack+postcss build with it, it fails with an error similar to: 

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '[redacted]/node_modules/sort-css-media-queries/lib/create-sort' imported from [redacted]/node_modules/sort-css-media-queries/lib/index.js
```

I searched a little, and it seems that following the step 4 here of this blog post https://electerious.medium.com/from-commonjs-to-es-modules-how-to-modernize-your-node-js-app-ad8cdd4fb662 solves the issue for me.

I fixed it locally, and indeed works (node v20.18.3). 

I'm not a usual node developer, but this also seems to be coherent with the indication of https://nodejs.org/api/esm.html#esm_mandatory_file_extensions, where file extensions are mandatory.