### PR TITLE
fix(readme): Missing "./lib/create-sort"

### DIFF
--- a/README-UK.md
+++ b/README-UK.md
@@ -161,7 +161,7 @@ postcss([
 та створити власний метод сортування з конфігурацією за необхідності:
 
 ```js
-import createSort from 'sort-css-media-queries/lib/create-sort';
+import createSort from 'sort-css-media-queries/create-sort';
 const sortCSSmq = createSort({ ...configuration });
 ```
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can import a separate sorting helper from a package
 and create your own sorting method with config as needed:
 
 ```js
-import createSort from 'sort-css-media-queries/lib/create-sort';
+import createSort from 'sort-css-media-queries/create-sort';
 const sortCSSmq = createSort({ ...configuration });
 ```
 


### PR DESCRIPTION
Fix error
```
Error: Missing "./lib/create-sort" specifier in "sort-css-media-queries" package
```

A different path is allowed in [package.json](https://github.com/OlehDutchenko/sort-css-media-queries/blob/56f635fcc77184025f751004110783344176bc9c/package.json#L29) `"./create-sort"`